### PR TITLE
Include missing pacakges in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,8 @@ scikit-learn==1.3.2
 scipy==1.11.3
 tabulate==0.9.0
 typing_extensions==4.8.0
+jsonpickle==3.3.0
+openpyxl==3.1.5
+lightgbm==4.5.0
+torch==2.4.1
+skorch==1.0.0


### PR DESCRIPTION
I was following the guide to setup df-analyze using pip but after performing all the steps, I was getting some missing modules errors, so I had to install them.